### PR TITLE
Refactor client for better data hiding via ES6.

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,23 +1,23 @@
-var KeycloakAdminClient = require('./');
+"use strict";
 
-var settings = {
-    baseUrl: 'http://192.168.99.100:8080/auth',
+let adminClient = require('./');
+
+let settings = {
+    baseUrl: 'http://127.0.0.1:8080/auth',
     username: 'admin',
     password: 'admin',
     grant_type: 'password',
     client_id: 'admin-cli'
 };
 
-
-var kc = new KeycloakAdminClient(settings);
-
-console.log(Object.keys(kc));
-
-kc.init().then(function (response) {
-    console.log(response.accessToken);
-    return kc.getRealms();
-}).then(function (realms) {
-    console.log('realms', realms);
-}).catch(function (err) {
-    console.log(err);
-});
+adminClient(settings).
+  then((client) => {
+    console.log('client', client);
+    client.realms().
+      then((realms) => {
+        console.log('realms', realms);
+      });
+  }).
+  catch((err) => {
+    console.log("Error", err);
+  });

--- a/lib/keycloak-admin-client.js
+++ b/lib/keycloak-admin-client.js
@@ -1,87 +1,78 @@
+"use strict";
 var request = require('request');
 
-function init (settings) {
-    var jsonParsedBody,
-        self = this;
+/**
+ settings  - {Object} - an object containing the settings
+ settings.baseUrl - {String} - The baseurl for the Keycloak server - ex: http://localhost:8080/auth,
+ settings.username
+ settings.password
+ settings.grant_type,
+ settings.client_id
+ */
+function keycloakAdminClient(settings) {
+  settings = settings || {};
 
-    return new Promise(function (resolve, reject) {
-        request.post({url: settings.baseUrl + settings.url, form: settings}, function (err, resp, body) {
-            if (err) {
-                return reject(err);
-            }
+  // setup our client and its private data
+  const data = {},
+        o = {};
+  o.realms = getRealms(o);
 
-            try {
-                jsonParsedBody = JSON.parse(body);
-            } catch (e) {
-                return reject(e);
-            }
+  // Make baseUrl unchanging
+  Object.defineProperty(o, 'baseUrl', {
+    value: settings.baseUrl
+  });
 
-            self._setAccessToken(jsonParsedBody.access_token);
+  // A WeakMap reference to our private data
+  // means that when all references to 'o' disappear
+  // then the entry will be removed from the map
+  privates.set(o, data);
 
-            return resolve({accessToken: jsonParsedBody.access_token, rawJSONBody: jsonParsedBody});
-        });
+  // return a promise that resolves after auth
+  return authenticate(o, settings);
+}
+
+function authenticate(client, settings) {
+  return new Promise((resolve, reject) => {
+    let req = {
+      url: client.baseUrl + '/realms/master/protocol/openid-connect/token',
+      form: settings
+    }, jsonParsedBody;
+
+    request.post(req, (err, resp, body) => {
+      if (err) {
+        return reject(err);
+      }
+
+      jsonParsedBody = JSON.parse(body);
+      privates.get(client).accessToken = jsonParsedBody.access_token;
+
+      return resolve(client);
     });
+  });
 }
 
 /**
-    settings  - {Object} - an object containing the settings
-    settings.baseUrl - {String} - The baseurl for the Keycloak server - ex: http://localhost:8080/auth,
-    settings.username
-    settings.password
-    settings.grant_type,
-    settings.client_id
-*/
-var KeyCloakAdminClient = function (settings) {
-    settings = settings || {};
+ Returns a function that can get the realms for the provided client.
+ */
+function getRealms(client) {
+  return function realms() {
+    return new Promise((resolve, reject) => {
+      let req = {
+        url: client.baseUrl + '/admin/realms',
+        auth: { bearer: privates.get(client).accessToken }
+      };
 
-    var accessToken;
+      request(req, (err, resp, body) => {
+        if (err) {
+          return reject(err);
+        }
 
-    settings.url = '/realms/master/protocol/openid-connect/token';
-
-    this._getBaseUrl = function () {
-        return settings.baseUrl;
-    };
-
-    this._getAccessToken = function () {
-        return accessToken;
-    };
-
-    this._setAccessToken = function (token) {
-        accessToken = token;
-    };
-
-    this.init = function () {
-        return init.call(this, settings);
-    };
-
-    return this;
-};
-
-KeyCloakAdminClient.prototype.getRealms = function () {
-    var self = this;
-
-    var auth = {
-         bearer: this._getAccessToken()
-    };
-
-    return new Promise(function (resolve, reject) {
-        request({
-            url: self._getBaseUrl() + '/admin/realms',
-            auth: auth
-        }, function (err, resp, body) {
-            if (err) {
-                return reject(err);
-            }
-
-            try {
-                jsonParsedBody = JSON.parse(body);
-            } catch (e) {
-                return reject(e);
-            }
-
-            return resolve(jsonParsedBody);
-        });
+        return resolve(JSON.parse(body));
+      });
     });
-};
+  };
+}
 
-module.exports = KeyCloakAdminClient;
+const privates = new WeakMap();
+
+module.exports = keycloakAdminClient;


### PR DESCRIPTION
Things got a bit more functional as well. The function exported from the
module is no longer a constructor, but a function that returns a
promise, eliminating the need for the user to explicitly call `init()`.
This is potentially awkward, since the only way to get a handle on the
client now is from `client().then((client) => {});` which may not be
ideal.

All of the "private" functions on the client are now hidden as
properties stored in a `WeakMap`, and the user-provided `baseUrl` is now
read only.

Happy to use this PR as a starting point for discussion before merging.
Comments welcome.