### PR TITLE
Use blue-tape instead of tape for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "request": "^2.69.0"
   },
   "devDependencies": {
+    "blue-tape": "^1.0.0",
     "eslint": "^3.5.0",
     "eslint-config-semistandard": "^7.0.0",
     "eslint-config-standard": "^6.0.0",

--- a/test/client-setup-test.js
+++ b/test/client-setup-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const test = require('tape');
+const test = require('blue-tape');
 const keycloakAdminClient = require('../index');
 
 test('keycloakAdminClient should return a promise containing the client object', (t) => {
@@ -15,10 +15,9 @@ test('keycloakAdminClient should return a promise containing the client object',
   const kca = keycloakAdminClient(settings);
 
   t.equal(kca instanceof Promise, true, 'should return a Promise');
-  kca.then((client) => {
+  return kca.then((client) => {
     t.equal(typeof client.baseUrl, 'string', 'client should contain a baseUrl String');
     t.equal(client.baseUrl, settings.baseUrl, 'client should contain a baseUrl String');
-    t.end();
   });
 });
 
@@ -33,10 +32,9 @@ test('keycloakAdminClient failed login, wrong user creds', (t) => {
 
   const kca = keycloakAdminClient(settings);
 
-  kca.catch((err) => {
+  return kca.then(() => t.fail('should rejected'), (err) => {
     t.equal(err.error_description, 'Invalid user credentials', 'error description should be invalid credentials');
     t.equal(err.error, 'invalid_grant', 'error invalid_grant');
-    t.end();
   });
 });
 
@@ -54,7 +52,5 @@ test('keycloakAdminClient should be able to log in successfully into another rea
   const kca = keycloakAdminClient(settings);
 
   t.equal(kca instanceof Promise, true, 'should return a Promise');
-  kca.then((client) => {
-    t.end();
-  });
+  return kca;
 });

--- a/test/clients-test.js
+++ b/test/clients-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const test = require('tape');
+const test = require('blue-tape');
 const keycloakAdminClient = require('../index');
 const kcSetupForTests = require('../scripts/kc-setup-for-tests.json');
 
@@ -15,19 +15,18 @@ const settings = {
 test('Test getting the list of clients for a Realm', (t) => {
   const kca = keycloakAdminClient(settings);
 
-  kca.then((client) => {
+  return kca.then((client) => {
     t.equal(typeof client.clients.find, 'function', 'The client object returned should have a clients.find function');
 
     // Use the master realm
     const realmName = 'master';
 
-    client.clients.find(realmName).then((listOfClients) => {
+    return client.clients.find(realmName).then((listOfClients) => {
       // The listOfCients should be an Array
       t.equal(listOfClients instanceof Array, true, 'the list of client should be an array');
 
       // The list of client in the master realm should have 4 people
       t.equal(listOfClients.length, 10, 'There should be 4 client in master');
-      t.end();
     });
   });
 });
@@ -35,32 +34,28 @@ test('Test getting the list of clients for a Realm', (t) => {
 test("Test getting the list of clients for a Realm that doesn't exist", (t) => {
   const kca = keycloakAdminClient(settings);
 
-  kca.then((client) => {
+  return kca.then((client) => {
     // Use the master realm
     const realmName = 'notarealrealm';
 
-    client.clients.find(realmName).catch((err) => {
-      t.equal(err, 'Realm not found.', "Realm not found should be returned if the realm wasn't found");
-      t.end();
-    });
+    return t.shouldFail(client.clients.find(realmName), 'Realm not found.', "Realm not found should be returned if the realm wasn't found");
   });
 });
 
 test('Test getting 1 client using query params for a Realm', (t) => {
   const kca = keycloakAdminClient(settings);
 
-  kca.then((client) => {
+  return kca.then((client) => {
     // Use the master realm
     const realmName = 'master';
     const options = {
       clientId: 'admin-cli'
     };
 
-    client.clients.find(realmName, options).then((listOfClients) => {
+    return client.clients.find(realmName, options).then((listOfClients) => {
       // The listOfClients should be an Array
       t.equal(listOfClients instanceof Array, true, 'the list of clients should be an array');
       t.equal(listOfClients.length, 1, 'There should be 1 client with this clientId in master');
-      t.end();
     });
   });
 });
@@ -68,15 +63,14 @@ test('Test getting 1 client using query params for a Realm', (t) => {
 test('Test getting the one client for a Realm', (t) => {
   const kca = keycloakAdminClient(settings);
 
-  kca.then((client) => {
+  return kca.then((client) => {
     // Use the master realm
     const realmName = 'master';
     const id = '294193ca-3506-4fc9-9b33-cc9d25bd0ec7'; // This is the admin-cli client id from /scripts/kc-setup-for-tests.json
 
-    client.clients.find(realmName, {id: id}).then((client) => {
+    return client.clients.find(realmName, {id: id}).then((client) => {
       t.equal(client.id, id, 'The client id we used and the one returned should be the same');
       t.equal(client.clientId, 'admin-cli', 'The clientId returned should be admin-cli');
-      t.end();
     });
   });
 });
@@ -84,22 +78,19 @@ test('Test getting the one client for a Realm', (t) => {
 test("Test getting the one client for a Realm - client id doesn't exist", (t) => {
   const kca = keycloakAdminClient(settings);
 
-  kca.then((client) => {
+  return kca.then((client) => {
     // Use the master realm
     const realmName = 'master';
     const id = 'not-an-id';
 
-    client.clients.find(realmName, {id: id}).catch((err) => {
-      t.equal(err, 'Could not find client', 'A Client not found error should be thrown');
-      t.end();
-    });
+    return t.shouldFail(client.clients.find(realmName, {id: id}), 'Could not find client', 'A Client not found error should be thrown');
   });
 });
 
 test('Test create a Client', (t) => {
   const kca = keycloakAdminClient(settings);
 
-  kca.then((client) => {
+  return kca.then((client) => {
     t.equal(typeof client.clients.create, 'function', 'The client object returned should have a create function');
 
     const realmName = 'Test Realm 1';
@@ -109,10 +100,9 @@ test('Test create a Client', (t) => {
       bearerOnly: true
     };
 
-    client.clients.create(realmName, newClient).then((addedClient) => {
+    return client.clients.create(realmName, newClient).then((addedClient) => {
       t.equal(addedClient.clientId, newClient.clientId, `The clientId should be named ${newClient.clientId}`);
       t.equal(addedClient.description, newClient.description, `The description should be named ${newClient.description}`);
-      t.end();
     });
   });
 });
@@ -127,10 +117,9 @@ test('Test create a Client - a not unique clientId', (t) => {
     description: 'just a test'
   };
 
-  kca.then((client) => {
-    client.clients.create(realmName, newClient).catch((err) => {
+  return kca.then((client) => {
+    return client.clients.create(realmName, newClient).catch((err) => {
       t.equal(err.errorMessage, 'Client admin-cli already exists', 'Error message should be returned when using a non-unique clientId');
-      t.end();
     });
   });
 });
@@ -138,7 +127,7 @@ test('Test create a Client - a not unique clientId', (t) => {
 test('Test update a client info', (t) => {
   const kca = keycloakAdminClient(settings);
 
-  kca.then((client) => {
+  return kca.then((client) => {
     t.equal(typeof client.clients.update, 'function', 'The client object returned should have a update function');
     // Use the Test Realm 1
     const realmName = 'Test Realm 1';
@@ -159,12 +148,11 @@ test('Test update a client info', (t) => {
     // Update the test client
     testClient.description = 'Update Description';
 
-    client.clients.update(realmName, testClient).then(() => {
+    return client.clients.update(realmName, testClient).then(() => {
       // The update doesn't return anything so we need to go get what we just updated
       return client.clients.find(realmName, {id: testClient.id});
     }).then((c) => {
       t.equal(c.description, testClient.description, 'The description returned should be the one we updated');
-      t.end();
     });
   });
 });
@@ -172,7 +160,7 @@ test('Test update a client info', (t) => {
 test('Test update a client info - same client id error', (t) => {
   const kca = keycloakAdminClient(settings);
 
-  kca.then((client) => {
+  return kca.then((client) => {
     // Use the Test Realm 1
     const realmName = 'Test Realm 1';
     const clientId = '38598d22-9592-4eec-819a-d6d91a6a1153';
@@ -191,9 +179,8 @@ test('Test update a client info - same client id error', (t) => {
     // Change the client id to the use for duplicate clients id, this will create an error since it already exists
     testClient.id = '09701f0c-db23-4b88-96d5-e35e4f766613';
 
-    client.clients.update(realmName, testClient).catch((err) => {
+    return client.clients.update(realmName, testClient).catch((err) => {
       t.equal(err.errorMessage, 'Client update me already exists', 'Should return an error message');
-      t.end();
     });
   });
 });
@@ -201,7 +188,7 @@ test('Test update a client info - same client id error', (t) => {
 test('Test update a client info - same clientId(really the name of the client) error', (t) => {
   const kca = keycloakAdminClient(settings);
 
-  kca.then((client) => {
+  return kca.then((client) => {
     // Use the Test Realm 1
     const realmName = 'Test Realm 1';
     const clientId = '38598d22-9592-4eec-819a-d6d91a6a1153';
@@ -220,17 +207,14 @@ test('Test update a client info - same clientId(really the name of the client) e
     // Change the client id to the use for duplicate clients id, this will create an error since it already exists
     testClient.clientId = 'use for duplicate';
 
-    client.clients.update(realmName, testClient).catch((err) => {
-      t.equal(err.errorMessage, 'Client use for duplicate already exists', 'Should return an error message');
-      t.end();
-    });
+    return t.shouldFail(client.clients.update(realmName, testClient), 'Client use for duplicate already exists', 'Should return an error message');
   });
 });
 
 test('Test update a client info - update a user that does not exist', (t) => {
   const kca = keycloakAdminClient(settings);
 
-  kca.then((client) => {
+  return kca.then((client) => {
     // Use the Test Realm 1
     const realmName = 'Test Realm 1';
     const clientId = '38598d22-9592-4eec-819a-d6d91a6a1153';
@@ -249,27 +233,21 @@ test('Test update a client info - update a user that does not exist', (t) => {
     // Change the user id to something that doesn't exist
     testClient.id = 'f9ea108b-a748-435f-9058-dab46ce5977-not-real';
 
-    client.clients.update(realmName, testClient).catch((err) => {
-      console.log(err);
-      t.equal(err, 'Could not find client', 'Should return an error that no client is found');
-      t.end();
-    });
+    return t.shouldFail(client.clients.update(realmName, testClient), 'Could not find client', 'Should return an error that no client is found');
   });
 });
 
 test('Test delete a client', (t) => {
   const kca = keycloakAdminClient(settings);
 
-  kca.then((client) => {
+  return kca.then((client) => {
     t.equal(typeof client.clients.remove, 'function', 'The client object returned should have a remove function');
 
     // Use the master realm
     const realmName = 'Test Realm 1';
     const id = 'd8c51041-84c7-4e76-901d-401e73eb1666';
 
-    client.clients.remove(realmName, id).then(() => {
-      t.end();
-    });
+    return client.clients.remove(realmName, id);
   });
 });
 
@@ -278,11 +256,8 @@ test("Test delete a client that doesn't exist", (t) => {
 
   const id = 'not-a-real-id';
   const realmName = 'master';
-  kca.then((client) => {
+  return kca.then((client) => {
     // Call the deleteRealm api to remove this realm
-    client.clients.remove(realmName, id).catch((err) => {
-      t.equal(err, 'Could not find client', 'Should return an error that no user is found');
-      t.end();
-    });
+    return t.shouldFail(client.clients.remove(realmName, id), 'Could not find client', 'Should return an error that no user is found');
   });
 });


### PR DESCRIPTION
blue-tape (as suggested on [the `tape` README](https://github.com/substack/tape#other) adds promise support to tape.

This improves the logging when a test fails, as it will cause the test to fail with the promise's error, instead of just triggering node's `UnhandledPromiseRejectionWarning` which doesn't even tell you which test failed.

It also automatically triggers `t.end()` when the promise is finished and provides the `t.shouldFail(promise)` assertion (promise equivalent of `t.throws(fn)`).