### PR TITLE
Add Client Role operations

### DIFF
--- a/lib/client-roles.js
+++ b/lib/client-roles.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const privates = require('./private-map');
+const request = require('request');
+
+/**
+ * @module clients
+ */
+
+module.exports = {
+  find: find,
+  create: create
+};
+
+/**
+  A function to get the all the roles of a client or a specific role for a client
+  @param {string} realmName - The name of the realm(not the realmID) to remove - ex: master,
+  @param {string} id - The id of the client(not the client-id) to remove
+  @param {string} roleName - The id of the client(not the client-id) to remove
+  @returns {Promise} A promise that will resolve with the Array of roles or just one role if the roleName option is used
+  @example
+  keycloakAdminClient(settings)
+    .then((client) => {
+      client.clients.roles.find(realmName, id)
+        .then((clientRoles) => {
+          console.log(clientRoles)
+      })
+    })
+ */
+function find (client) {
+  return function find (realmName, id, roleName) {
+    return new Promise((resolve, reject) => {
+      const req = {
+        auth: {
+          bearer: privates.get(client).accessToken
+        },
+        json: true
+      };
+
+      if (roleName) {
+        req.url = `${client.baseUrl}/admin/realms/${realmName}/clients/${id}/roles/${roleName}`;
+      } else {
+        req.url = `${client.baseUrl}/admin/realms/${realmName}/clients/${id}/roles`;
+      }
+
+      request(req, (err, resp, body) => {
+        if (err) {
+          return reject(err);
+        }
+
+        if (resp.statusCode !== 200) {
+          return reject(body);
+        }
+
+        return resolve(body);
+      });
+    });
+  };
+}
+
+/**
+  A function to create a new role.
+  @param {string} realmName - The name of the realm(not the realmID) - ex: master
+  @param {string} id - The id of the client(not the client-id) to remove
+  @param {object} newRole - The JSON representation of a role - http://www.keycloak.org/docs-api/3.0/rest-api/index.html#_rolerepresentation - name must be unique within the client
+  @returns {Promise} A promise that will resolve with the new clients object
+  @example
+  keycloakAdminClient(settings)
+    .then((client) => {
+      client.clients.roles.create(realmName, id, newRole)
+        .then((createRole) => {
+        console.log(createRole) // [{...}]
+      })
+    })
+ */
+function create (client) {
+  return function create (realm, id, newRole) {
+    return new Promise((resolve, reject) => {
+      const req = {
+        url: `${client.baseUrl}/admin/realms/${realm}/clients/${id}/roles`,
+        auth: {
+          bearer: privates.get(client).accessToken
+        },
+        body: newRole,
+        method: 'POST',
+        json: true
+      };
+
+      request(req, (err, resp, body) => {
+        if (err) {
+          return reject(err);
+        }
+
+        if (resp.statusCode !== 201) {
+          return reject(body);
+        }
+
+        // Since the create Endpoint returns an empty body, go get what we just imported.
+        return resolve(client.clients.roles.find(realm, id, newRole.name));
+      });
+    });
+  };
+}

--- a/lib/clients.js
+++ b/lib/clients.js
@@ -12,7 +12,8 @@ module.exports = {
   create: create,
   update: update,
   remove: remove,
-  getClientSecret: getClientSecret
+  getClientSecret: getClientSecret,
+  getRoles: getRoles
 };
 
 /**
@@ -212,6 +213,46 @@ function getClientSecret (client) {
     return new Promise((resolve, reject) => {
       const req = {
         url: `${client.baseUrl}/admin/realms/${realmName}/clients/${id}/client-secret`,
+        auth: {
+          bearer: privates.get(client).accessToken
+        },
+        json: true
+      };
+
+      request(req, (err, resp, body) => {
+        if (err) {
+          return reject(err);
+        }
+
+        if (resp.statusCode !== 200) {
+          return reject(body);
+        }
+
+        return resolve(body);
+      });
+    });
+  };
+}
+
+/**
+  A function to get the roles of a client
+  @param {string} realmName - The name of the realm(not the realmID) to remove - ex: master,
+  @param {string} id - The id of the client(not the client-id) to remove
+  @returns {Promise} A promise that resolves.
+  @example
+  keycloakAdminClient(settings)
+    .then((client) => {
+      client.clients.getRoles(realmName, id)
+        .then((clientRoles) => {
+          console.log(clientRoles)
+      })
+    })
+ */
+function getRoles (client) {
+  return function getRoles (realmName, id) {
+    return new Promise((resolve, reject) => {
+      const req = {
+        url: `${client.baseUrl}/admin/realms/${realmName}/clients/${id}/roles`,
         auth: {
           bearer: privates.get(client).accessToken
         },

--- a/lib/clients.js
+++ b/lib/clients.js
@@ -14,7 +14,8 @@ module.exports = {
   remove: remove,
   getClientSecret: getClientSecret,
   getRoles: getRoles,
-  getRole: getRole
+  getRole: getRole,
+  createRole: createRole
 };
 
 /**
@@ -312,6 +313,50 @@ function getRole (client) {
 
         // Since the create Endpoint returns an empty body, go get what we just imported.
         return resolve(body);
+      });
+    });
+  };
+}
+
+/**
+  A function to create a new role.
+  @param {string} realmName - The name of the realm(not the realmID) - ex: master
+  @param {string} id - The id of the client(not the client-id) to remove
+  @param {object} newRole - The JSON representation of a role - http://www.keycloak.org/docs-api/3.0/rest-api/index.html#_rolerepresentation - name must be unique within the client
+  @returns {Promise} A promise that will resolve with the new clients object
+  @example
+  keycloakAdminClient(settings)
+    .then((client) => {
+      client.clients.createRole(realmName, id, newRole)
+        .then((createRole) => {
+        console.log(createRole) // [{...}]
+      })
+    })
+ */
+function createRole (client) {
+  return function createRole (realm, id, newRole) {
+    return new Promise((resolve, reject) => {
+      const req = {
+        url: `${client.baseUrl}/admin/realms/${realm}/clients/${id}/roles`,
+        auth: {
+          bearer: privates.get(client).accessToken
+        },
+        body: newRole,
+        method: 'POST',
+        json: true
+      };
+
+      request(req, (err, resp, body) => {
+        if (err) {
+          return reject(err);
+        }
+
+        if (resp.statusCode !== 201) {
+          return reject(body);
+        }
+
+        // Since the create Endpoint returns an empty body, go get what we just imported.
+        return resolve(client.clients.getRole(realm, id, newRole.name));
       });
     });
   };

--- a/lib/clients.js
+++ b/lib/clients.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const privates = require('./private-map');
+const roles = require('./client-roles');
 const request = require('request');
 
 /**
@@ -13,9 +14,7 @@ module.exports = {
   update: update,
   remove: remove,
   getClientSecret: getClientSecret,
-  getRoles: getRoles,
-  getRole: getRole,
-  createRole: createRole
+  roles: roles
 };
 
 /**
@@ -231,132 +230,6 @@ function getClientSecret (client) {
         }
 
         return resolve(body);
-      });
-    });
-  };
-}
-
-/**
-  A function to get the roles of a client
-  @param {string} realmName - The name of the realm(not the realmID) to remove - ex: master,
-  @param {string} id - The id of the client(not the client-id) to remove
-  @returns {Promise} A promise that resolves.
-  @example
-  keycloakAdminClient(settings)
-    .then((client) => {
-      client.clients.getRoles(realmName, id)
-        .then((clientRoles) => {
-          console.log(clientRoles)
-      })
-    })
- */
-function getRoles (client) {
-  return function getRoles (realmName, id) {
-    return new Promise((resolve, reject) => {
-      const req = {
-        url: `${client.baseUrl}/admin/realms/${realmName}/clients/${id}/roles`,
-        auth: {
-          bearer: privates.get(client).accessToken
-        },
-        json: true
-      };
-
-      request(req, (err, resp, body) => {
-        if (err) {
-          return reject(err);
-        }
-
-        if (resp.statusCode !== 200) {
-          return reject(body);
-        }
-
-        return resolve(body);
-      });
-    });
-  };
-}
-
-/**
-  A function to get a single role of a client
-  @param {string} realmName - The name of the realm(not the realmID) to remove - ex: master,
-  @param {string} id - The id of the client(not the client-id) to remove
-  @param {string} roleName - The id of the client(not the client-id) to remove
-  @returns {Promise} A promise that resolves.
-  @example
-  keycloakAdminClient(settings)
-    .then((client) => {
-      client.clients.getRole(realmName, id, roleName)
-        .then((clientRole) => {
-          console.log(clientRole)
-      })
-    })
- */
-function getRole (client) {
-  return function getRole (realmName, id, roleName) {
-    return new Promise((resolve, reject) => {
-      const req = {
-        url: `${client.baseUrl}/admin/realms/${realmName}/clients/${id}/roles/${roleName}`,
-        auth: {
-          bearer: privates.get(client).accessToken
-        },
-        json: true
-      };
-
-      request(req, (err, resp, body) => {
-        if (err) {
-          return reject(err);
-        }
-
-        if (resp.statusCode !== 200) {
-          return reject(body);
-        }
-
-        // Since the create Endpoint returns an empty body, go get what we just imported.
-        return resolve(body);
-      });
-    });
-  };
-}
-
-/**
-  A function to create a new role.
-  @param {string} realmName - The name of the realm(not the realmID) - ex: master
-  @param {string} id - The id of the client(not the client-id) to remove
-  @param {object} newRole - The JSON representation of a role - http://www.keycloak.org/docs-api/3.0/rest-api/index.html#_rolerepresentation - name must be unique within the client
-  @returns {Promise} A promise that will resolve with the new clients object
-  @example
-  keycloakAdminClient(settings)
-    .then((client) => {
-      client.clients.createRole(realmName, id, newRole)
-        .then((createRole) => {
-        console.log(createRole) // [{...}]
-      })
-    })
- */
-function createRole (client) {
-  return function createRole (realm, id, newRole) {
-    return new Promise((resolve, reject) => {
-      const req = {
-        url: `${client.baseUrl}/admin/realms/${realm}/clients/${id}/roles`,
-        auth: {
-          bearer: privates.get(client).accessToken
-        },
-        body: newRole,
-        method: 'POST',
-        json: true
-      };
-
-      request(req, (err, resp, body) => {
-        if (err) {
-          return reject(err);
-        }
-
-        if (resp.statusCode !== 201) {
-          return reject(body);
-        }
-
-        // Since the create Endpoint returns an empty body, go get what we just imported.
-        return resolve(client.clients.getRole(realm, id, newRole.name));
       });
     });
   };

--- a/lib/clients.js
+++ b/lib/clients.js
@@ -13,7 +13,8 @@ module.exports = {
   update: update,
   remove: remove,
   getClientSecret: getClientSecret,
-  getRoles: getRoles
+  getRoles: getRoles,
+  getRole: getRole
 };
 
 /**
@@ -268,6 +269,48 @@ function getRoles (client) {
           return reject(body);
         }
 
+        return resolve(body);
+      });
+    });
+  };
+}
+
+/**
+  A function to get a single role of a client
+  @param {string} realmName - The name of the realm(not the realmID) to remove - ex: master,
+  @param {string} id - The id of the client(not the client-id) to remove
+  @param {string} roleName - The id of the client(not the client-id) to remove
+  @returns {Promise} A promise that resolves.
+  @example
+  keycloakAdminClient(settings)
+    .then((client) => {
+      client.clients.getRole(realmName, id, roleName)
+        .then((clientRole) => {
+          console.log(clientRole)
+      })
+    })
+ */
+function getRole (client) {
+  return function getRole (realmName, id, roleName) {
+    return new Promise((resolve, reject) => {
+      const req = {
+        url: `${client.baseUrl}/admin/realms/${realmName}/clients/${id}/roles/${roleName}`,
+        auth: {
+          bearer: privates.get(client).accessToken
+        },
+        json: true
+      };
+
+      request(req, (err, resp, body) => {
+        if (err) {
+          return reject(err);
+        }
+
+        if (resp.statusCode !== 200) {
+          return reject(body);
+        }
+
+        // Since the create Endpoint returns an empty body, go get what we just imported.
         return resolve(body);
       });
     });

--- a/lib/kc-admin-client.js
+++ b/lib/kc-admin-client.js
@@ -9,6 +9,21 @@ const realms = require('./realms');
 const users = require('./users');
 const clients = require('./clients');
 
+function bindModule (client, input) {
+  // For an
+  if (typeof input === 'object') {
+    const initializedModule = {};
+    for (const name in input) {
+      initializedModule[name] = bindModule(client, input[name]);
+    }
+    return initializedModule;
+  } else if (typeof input === 'function') {
+    return input(client);
+  } else {
+    throw new Error(`Unexpected input module type: ${input}`);
+  }
+}
+
 /**
   Creates a new Keycloak Admin client
   @param {object} settings - an object containing the settings
@@ -43,26 +58,14 @@ function keycloakAdminClient (settings) {
 
   // setup our client and its private data
   const data = {};
-  const client = {
-    realms: {},
-    users: {},
-    clients: {}
-  };
+  const client = {};
 
-  // Add in the realms functions
-  for (const func in realms) {
-    client.realms[func] = realms[func](client);
-  }
-
-  // Add in the user functions
-  for (const func in users) {
-    client.users[func] = users[func](client);
-  }
-
-  // Add in the client functions
-  for (const func in clients) {
-    client.clients[func] = clients[func](client);
-  }
+  // Recursively bind the modules to the client
+  Object.assign(client, bindModule(client, {
+    realms: realms,
+    users: users,
+    clients: clients
+  }));
 
   // Make baseUrl unchanging
   Object.defineProperty(client, 'baseUrl', {

--- a/test/clients-test.js
+++ b/test/clients-test.js
@@ -321,3 +321,47 @@ test("Test getting a client's roles - client id doesn't exist", (t) => {
     return t.shouldFail(client.clients.getRoles(realmName, id), 'Could not find client', 'Should return an error that no user is found');
   });
 });
+
+test("Test getting a client's role", (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    // Use the master realm
+    const realmName = 'master';
+    const id = '379efc29-4b2e-403c-83b6-d9c9af43b24a'; // This is the master-realm client id from /scripts/kc-setup-for-tests.json
+    const roleName = 'manage-identity-providers';
+
+    return client.clients.getRole(realmName, id, roleName).then((role) => {
+      const expectedRole = {
+        id: 'a16e820e-ae47-4ac9-82ba-683c0b866994',
+        name: 'manage-identity-providers',
+        description: `\${role_manage-identity-providers}`,
+        scopeParamRequired: false,
+        composite: false
+      };
+      t.deepEqual(role, expectedRole, 'Should return the manage-identity-providers role');
+    });
+  });
+});
+
+test("Test getting a client's role - client id doesn't exist", (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  const realmName = 'master';
+  const id = 'not-a-real-id';
+  const roleName = 'not-a-real-role-name';
+  return kca.then((client) => {
+    return t.shouldFail(client.clients.getRole(realmName, id, roleName), 'Could not find client', 'Should return an error that no client is found');
+  });
+});
+
+test("Test getting a client's role - role name doesn't exist", (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  const realmName = 'master';
+  const id = '379efc29-4b2e-403c-83b6-d9c9af43b24a'; // This is the master-realm client id from /scripts/kc-setup-for-tests.json
+  const roleName = 'not-a-real-role-name';
+  return kca.then((client) => {
+    return t.shouldFail(client.clients.getRole(realmName, id, roleName), 'Could not find role', 'Should return an error that no role is found');
+  });
+});

--- a/test/clients-test.js
+++ b/test/clients-test.js
@@ -288,3 +288,36 @@ test("Test getting the client secret - client id doesn't exist", (t) => {
     return t.shouldFail(client.clients.getClientSecret(realmName, id), 'Could not find client', 'A Client not found error should be thrown');
   });
 });
+
+test("Test getting a client's roles", (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    // Use the master realm
+    const realmName = 'master';
+    const id = '379efc29-4b2e-403c-83b6-d9c9af43b24a'; // This is the master-realm client id from /scripts/kc-setup-for-tests.json
+
+    return client.clients.getRoles(realmName, id).then((roles) => {
+      t.equal(roles.length, 12, 'Should return 12 roles');
+
+      const expectedRole = {
+        id: 'a16e820e-ae47-4ac9-82ba-683c0b866994',
+        name: 'manage-identity-providers',
+        description: `\${role_manage-identity-providers}`,
+        scopeParamRequired: false,
+        composite: false
+      };
+      t.deepEqual(roles.find((r) => r.id === expectedRole.id), expectedRole, 'Should have the manage-identity-providers role');
+    });
+  });
+});
+
+test("Test getting a client's roles - client id doesn't exist", (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  const id = 'not-a-real-id';
+  const realmName = 'master';
+  return kca.then((client) => {
+    return t.shouldFail(client.clients.getRoles(realmName, id), 'Could not find client', 'Should return an error that no user is found');
+  });
+});

--- a/test/clients-test.js
+++ b/test/clients-test.js
@@ -365,3 +365,54 @@ test("Test getting a client's role - role name doesn't exist", (t) => {
     return t.shouldFail(client.clients.getRole(realmName, id, roleName), 'Could not find role', 'Should return an error that no role is found');
   });
 });
+
+test('Test create a client role', (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    const realmName = 'master';
+    const id = '294193ca-3506-4fc9-9b33-cc9d25bd0ec7'; // This is the admin-cli client id from /scripts/kc-setup-for-tests.json
+    const newRole = {
+      name: 'my-new-role',
+      description: 'A new role'
+    };
+
+    return client.clients.createRole(realmName, id, newRole).then((addedRole) => {
+      t.equal(addedRole.name, newRole.name, `The name should be named ${newRole.name}`);
+      t.equal(addedRole.description, newRole.description, `The description should be named ${newRole.description}`);
+    });
+  });
+});
+
+test("Test create a client role - client id doesn't exist", (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    const realmName = 'master';
+    const id = 'not-a-real-id';
+    const newRole = {
+      name: 'my-new-role',
+      description: 'A new role'
+    };
+
+    return kca.then((client) => {
+      return t.shouldFail(client.clients.createRole(realmName, id, newRole), 'Could not find client', 'Should return an error that no client is found');
+    });
+  });
+});
+
+test('Test create a client role - a non-unique role name', (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    const realmName = 'master';
+    const id = '379efc29-4b2e-403c-83b6-d9c9af43b24a'; // This is the master-realm client id from /scripts/kc-setup-for-tests.json
+    const newRole = {
+      name: 'manage-identity-providers'
+    };
+
+    return kca.then((client) => {
+      return t.shouldFail(client.clients.createRole(realmName, id, newRole), `Role ${newRole.name} already exists`, 'Error message should be returned when using a non-unique role name');
+    });
+  });
+});

--- a/test/clients-test.js
+++ b/test/clients-test.js
@@ -297,7 +297,7 @@ test("Test getting a client's roles", (t) => {
     const realmName = 'master';
     const id = '379efc29-4b2e-403c-83b6-d9c9af43b24a'; // This is the master-realm client id from /scripts/kc-setup-for-tests.json
 
-    return client.clients.getRoles(realmName, id).then((roles) => {
+    return client.clients.roles.find(realmName, id).then((roles) => {
       t.equal(roles.length, 12, 'Should return 12 roles');
 
       const expectedRole = {
@@ -318,7 +318,7 @@ test("Test getting a client's roles - client id doesn't exist", (t) => {
   const id = 'not-a-real-id';
   const realmName = 'master';
   return kca.then((client) => {
-    return t.shouldFail(client.clients.getRoles(realmName, id), 'Could not find client', 'Should return an error that no user is found');
+    return t.shouldFail(client.clients.roles.find(realmName, id), 'Could not find client', 'Should return an error that no user is found');
   });
 });
 
@@ -331,7 +331,7 @@ test("Test getting a client's role", (t) => {
     const id = '379efc29-4b2e-403c-83b6-d9c9af43b24a'; // This is the master-realm client id from /scripts/kc-setup-for-tests.json
     const roleName = 'manage-identity-providers';
 
-    return client.clients.getRole(realmName, id, roleName).then((role) => {
+    return client.clients.roles.find(realmName, id, roleName).then((role) => {
       const expectedRole = {
         id: 'a16e820e-ae47-4ac9-82ba-683c0b866994',
         name: 'manage-identity-providers',
@@ -351,7 +351,7 @@ test("Test getting a client's role - client id doesn't exist", (t) => {
   const id = 'not-a-real-id';
   const roleName = 'not-a-real-role-name';
   return kca.then((client) => {
-    return t.shouldFail(client.clients.getRole(realmName, id, roleName), 'Could not find client', 'Should return an error that no client is found');
+    return t.shouldFail(client.clients.roles.find(realmName, id, roleName), 'Could not find client', 'Should return an error that no client is found');
   });
 });
 
@@ -362,7 +362,7 @@ test("Test getting a client's role - role name doesn't exist", (t) => {
   const id = '379efc29-4b2e-403c-83b6-d9c9af43b24a'; // This is the master-realm client id from /scripts/kc-setup-for-tests.json
   const roleName = 'not-a-real-role-name';
   return kca.then((client) => {
-    return t.shouldFail(client.clients.getRole(realmName, id, roleName), 'Could not find role', 'Should return an error that no role is found');
+    return t.shouldFail(client.clients.roles.find(realmName, id, roleName), 'Could not find role', 'Should return an error that no role is found');
   });
 });
 
@@ -377,7 +377,7 @@ test('Test create a client role', (t) => {
       description: 'A new role'
     };
 
-    return client.clients.createRole(realmName, id, newRole).then((addedRole) => {
+    return client.clients.roles.create(realmName, id, newRole).then((addedRole) => {
       t.equal(addedRole.name, newRole.name, `The name should be named ${newRole.name}`);
       t.equal(addedRole.description, newRole.description, `The description should be named ${newRole.description}`);
     });
@@ -396,7 +396,7 @@ test("Test create a client role - client id doesn't exist", (t) => {
     };
 
     return kca.then((client) => {
-      return t.shouldFail(client.clients.createRole(realmName, id, newRole), 'Could not find client', 'Should return an error that no client is found');
+      return t.shouldFail(client.clients.roles.create(realmName, id, newRole), 'Could not find client', 'Should return an error that no client is found');
     });
   });
 });
@@ -412,7 +412,7 @@ test('Test create a client role - a non-unique role name', (t) => {
     };
 
     return kca.then((client) => {
-      return t.shouldFail(client.clients.createRole(realmName, id, newRole), `Role ${newRole.name} already exists`, 'Error message should be returned when using a non-unique role name');
+      return t.shouldFail(client.clients.roles.create(realmName, id, newRole), `Role ${newRole.name} already exists`, 'Error message should be returned when using a non-unique role name');
     });
   });
 });


### PR DESCRIPTION
Adds `clients.getRoles()`, `clients.getRole()` and `clients.createRole()` operations.

Alternatively, I could move them to be `client.roles.find()` and `clients.roles.create()`  (there didn't seem to be an existing pattern for this in the current methods).