### PR TITLE
Allow supplying an access token

### DIFF
--- a/example-with-request.js
+++ b/example-with-request.js
@@ -25,7 +25,7 @@ request.post({url: baseUrl + url, form: config}, function (err, resp, body) {
   };
 
   request({
-    url: baseUrl + '/admin/realms',
+    url: `${baseUrl}/admin/realms`,
     auth: auth
   }, function (err, response, body) {
     if (err) {
@@ -38,7 +38,7 @@ request.post({url: baseUrl + url, form: config}, function (err, resp, body) {
     console.log('Got All Realms', realms);
 
     request({
-      url: baseUrl + '/admin/realms/' + realms[0].realm,
+      url: `${baseUrl}/admin/realms/${realms[0].realm}`,
       auth: auth
     }, function (err, response, body) {
       if (err) {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,7 +1,14 @@
 'use strict';
 
 const privates = require('./private-map');
-const getToken = require('keycloak-request-token');
+const requestToken = require('keycloak-request-token');
+
+function getToken (baseUrl, settings) {
+  if (settings.accessToken) {
+    return Promise.resolve(settings.accessToken);
+  }
+  return requestToken(baseUrl, settings);
+}
 
 function authenticate (client, settings) {
   return getToken(client.baseUrl, settings)

--- a/lib/kc-admin-client.js
+++ b/lib/kc-admin-client.js
@@ -33,6 +33,7 @@ function bindModule (client, input) {
   @param {string} settings.grant_type - the type of authentication mechanism - ex: password,
   @param {string} settings.client_id - the id of the client that is registered with Keycloak to connect to - ex: admin-cli
   @param {string} settings.realmName - the name of the realm to login to - defaults to 'masterg'
+  @param {string} settings.accessToken - An access token to use instead of authenticating via username & password
   @returns {Promise} A promise that will resolve with the client object.
   @instance
   @example

--- a/test/client-setup-test.js
+++ b/test/client-setup-test.js
@@ -2,6 +2,7 @@
 
 const test = require('blue-tape');
 const keycloakAdminClient = require('../index');
+const privates = require('../lib/private-map');
 
 test('keycloakAdminClient should return a promise containing the client object', (t) => {
   const settings = {
@@ -53,4 +54,18 @@ test('keycloakAdminClient should be able to log in successfully into another rea
 
   t.equal(kca instanceof Promise, true, 'should return a Promise');
   return kca;
+});
+
+test('keycloakAdminClient should accept and use a token in lieue of credentials', (t) => {
+  const settings = {
+    baseUrl: 'http://127.0.0.1:8080/auth',
+    accessToken: 'an-access-token'
+  };
+
+  const kca = keycloakAdminClient(settings);
+
+  t.equal(kca instanceof Promise, true, 'should return a Promise');
+  return kca.then((client) => {
+    t.equal(privates.get(client).accessToken, settings.accessToken, 'client should contain a baseUrl String');
+  });
 });

--- a/test/client-setup-test.js
+++ b/test/client-setup-test.js
@@ -66,6 +66,6 @@ test('keycloakAdminClient should accept and use a token in lieue of credentials'
 
   t.equal(kca instanceof Promise, true, 'should return a Promise');
   return kca.then((client) => {
-    t.equal(privates.get(client).accessToken, settings.accessToken, 'client should contain a baseUrl String');
+    t.equal(privates.get(client).accessToken, settings.accessToken, 'client should have the provided access token');
   });
 });

--- a/test/realms-test.js
+++ b/test/realms-test.js
@@ -63,7 +63,7 @@ test('Test create a realm - just using a realm name', (t) => {
     return client.realms.create(realmToAdd).then((addedRealm) => {
       // The .realms.create Endpoint does not return anything in the body.
       // But our api "fakes it" by calling the client.realm(realm) function after a succesfull create.
-      t.equal(addedRealm.realm, realmToAdd.realm, 'The realm should be named ' + realmToAdd.realm);
+      t.equal(addedRealm.realm, realmToAdd.realm, `The realm should be named ${realmToAdd.realm}`);
 
       // clean up the realm we just added. This is only really needed when running tests locally.
       // remove is tested later on
@@ -98,7 +98,7 @@ test('Test delete a realm', (t) => {
   return kca.then((client) => {
     return client.realms.create(realmToAdd).then((addedRealm) => {
       // just a quick quick that the realm is there
-      t.equal(addedRealm.realm, realmToAdd.realm, 'The realm should be named ' + realmToAdd.realm);
+      t.equal(addedRealm.realm, realmToAdd.realm, `The realm should be named ${realmToAdd.realm}`);
 
       // Call the remove api to remove this realm
       return client.realms.remove(realmToAdd.realm);
@@ -132,7 +132,7 @@ test('Test update a realm', (t) => {
   return kca.then((client) => {
     client.realms.create(realmToAdd).then((addedRealm) => {
       // just a quick quick that the realm is there
-      t.equal(addedRealm.realm, realmToAdd.realm, 'The realm should be named ' + realmToAdd.realm);
+      t.equal(addedRealm.realm, realmToAdd.realm, `The realm should be named ${realmToAdd.realm}`);
       t.equal(addedRealm.enabled, false, 'initial enabled is false');
 
       // Update a property in the realm we just created


### PR DESCRIPTION
Addresses #24 by adding `settings.accessToken` when instantiating a `new keycloakAdminClient()`.

Also changes a few string concats to templates to resolve the linter warnings.