### PR TITLE
Fixing some of the client role documentation

### DIFF
--- a/lib/client-roles.js
+++ b/lib/client-roles.js
@@ -14,9 +14,9 @@ module.exports = {
 
 /**
   A function to get the all the roles of a client or a specific role for a client
-  @param {string} realmName - The name of the realm(not the realmID) to remove - ex: master,
-  @param {string} id - The id of the client(not the client-id) to remove
-  @param {string} roleName - The id of the client(not the client-id) to remove
+  @param {string} realmName - The name of the realm (not the realmID) where the client roles exist - ex: master
+  @param {string} id - The id of the client (not the client-id) whose roles should be found
+  @param {string} roleName - Optional name of a specific client role to find
   @returns {Promise} A promise that will resolve with the Array of roles or just one role if the roleName option is used
   @example
   keycloakAdminClient(settings)
@@ -60,10 +60,10 @@ function find (client) {
 
 /**
   A function to create a new role.
-  @param {string} realmName - The name of the realm(not the realmID) - ex: master
-  @param {string} id - The id of the client(not the client-id) to remove
+  @param {string} realmName - The name of the realm (not the realmID) where the client roles exist - ex: master
+  @param {string} id - The id of the client (not the client-id) whose roles should be found
   @param {object} newRole - The JSON representation of a role - http://www.keycloak.org/docs-api/3.0/rest-api/index.html#_rolerepresentation - name must be unique within the client
-  @returns {Promise} A promise that will resolve with the new clients object
+  @returns {Promise} A promise that will resolve with the newly created client role
   @example
   keycloakAdminClient(settings)
     .then((client) => {


### PR DESCRIPTION
Seems like maybe these docs were unchanged after getting copied from some other component. Updating to (hopefully) an accurate representation.