### PR TITLE
Support for mapping realm and client roles to users

### DIFF
--- a/lib/client-role-mapper.js
+++ b/lib/client-role-mapper.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const privates = require('./private-map');
+const request = require('request');
+
+/**
+ * @module clients
+ */
+
+module.exports = {
+  map: map,
+  unmap: unmap
+};
+
+/**
+  A function to map one or more client roles to a given user
+  @param {string} realmName - The name of the realm (not the realmID) where the client roles exist - ex: master
+  @param {string} usrid - The id of the user (UUID)
+  @param {string} clientid - The id of the client (not the client-id) owning the roles
+  @param {string} roles - Array containing client roles to be assigned
+  @returns {Promise} A promise that will resolve with the Array of roles
+  @example
+  keycloakAdminClient(settings)
+    .then((client) => {
+      client.clients.maps.map(realmName, usrid, clientid, roles)
+        .then((assignedClientRoles) => {
+          console.log(assignedClientRoles)
+      })
+    })
+ */
+function map (client) {
+  return function map (realmName, usrid, clientid, roles) {
+    return new Promise((resolve, reject) => {
+      if (!usrid) {
+        return reject(new Error('user id is missing'));
+      }
+
+      if (!clientid) {
+        return reject(new Error('client id is missing'));
+      }
+
+      if (!roles || !(roles instanceof Array) || roles.length === 0) {
+        return reject(new Error('roles are missing'));
+      }
+
+      const req = {
+        url: `${client.baseUrl}/admin/realms/${realmName}/users/${usrid}/role-mappings/clients/${clientid}`,
+        auth: {
+          bearer: privates.get(client).accessToken
+        },
+        body: roles,
+        method: 'POST',
+        json: true
+      };
+
+      request(req, (err, resp, body) => {
+        if (err) {
+          return reject(err);
+        }
+
+        if (resp.statusCode !== 204) {
+          return reject(body);
+        }
+
+        return resolve(body);
+      });
+    });
+  };
+}
+
+/**
+  A function to unmap one or more client roles from a given user
+  @param {string} realmName - The name of the realm (not the realmID) where the client roles exist - ex: master
+  @param {string} usrid - The id of the user (UUID)
+  @param {string} clientid - The id of the client (not the client-id) owning the roles
+  @param {string} roles - Array containing client roles to be unassigned
+  @returns {Promise} A promise that will resolve with the Array of roles
+  @example
+  keycloakAdminClient(settings)
+    .then((client) => {
+      client.clients.maps.unmap(realmName, usrid, clientid, roles)
+        .then((unassignedClientRoles) => {
+          console.log(unassignedClientRoles)
+      })
+    })
+ */
+function unmap (client) {
+  return function unmap (realmName, usrid, clientid, roles) {
+    return new Promise((resolve, reject) => {
+      if (!usrid) {
+        return reject(new Error('user id is missing'));
+      }
+
+      if (!clientid) {
+        return reject(new Error('client id is missing'));
+      }
+
+      if (!roles || !(roles instanceof Array) || roles.length === 0) {
+        return reject(new Error('roles are missing'));
+      }
+
+      const req = {
+        url: `${client.baseUrl}/admin/realms/${realmName}/users/${usrid}/role-mappings/clients/${clientid}`,
+        auth: {
+          bearer: privates.get(client).accessToken
+        },
+        body: roles,
+        method: 'DELETE',
+        json: true
+      };
+
+      request(req, (err, resp, body) => {
+        if (err) {
+          return reject(err);
+        }
+
+        if (resp.statusCode !== 204) {
+          return reject(body);
+        }
+
+        return resolve(body);
+      });
+    });
+  };
+}

--- a/lib/clients.js
+++ b/lib/clients.js
@@ -3,6 +3,7 @@
 const privates = require('./private-map');
 const roles = require('./client-roles');
 const request = require('request');
+const maps = require('./client-role-mapper');
 
 /**
  * @module clients
@@ -15,7 +16,8 @@ module.exports = {
   remove: remove,
   getClientSecret: getClientSecret,
   roles: roles,
-  installation: installation
+  installation: installation,
+  maps: maps
 };
 
 /**

--- a/lib/kc-admin-client.js
+++ b/lib/kc-admin-client.js
@@ -14,6 +14,8 @@ function bindModule (client, input) {
   // For an
   if (typeof input === 'object') {
     const initializedModule = {};
+    // https://github.com/bucharest-gold/keycloak-admin-client/issues/40
+    // eslint-disable-next-line prefer-const
     for (let name in input) {
       initializedModule[name] = bindModule(client, input[name]);
     }

--- a/lib/realm-role-mapper.js
+++ b/lib/realm-role-mapper.js
@@ -1,0 +1,115 @@
+'use strict';
+
+const privates = require('./private-map');
+const request = require('request');
+
+/**
+ * @module clients
+ */
+
+module.exports = {
+  map: map,
+  unmap: unmap
+};
+
+/**
+  A function to map one or more realm roles to a given user
+  @param {string} realmName - The name of the realm (not the realmID) where the roles exist - ex: master
+  @param {string} usrid - The id of the user (UUID)
+  @param {string} roles - Array containing realm roles to be assigned
+  @returns {Promise} A promise that will resolve with the Array of roles
+  @example
+  keycloakAdminClient(settings)
+    .then((client) => {
+      client.realms.maps.map(realmName, usrid, roles)
+        .then((assignedRealmRoles) => {
+          console.log(assignedRealmRoles)
+      })
+    })
+ */
+function map (client) {
+  return function map (realmName, usrid, roles) {
+    return new Promise((resolve, reject) => {
+      if (!usrid) {
+        return reject(new Error('user id is missing'));
+      }
+
+      if (!roles || !(roles instanceof Array) || roles.length === 0) {
+        return reject(new Error('roles are missing'));
+      }
+
+      const req = {
+        url: `${client.baseUrl}/admin/realms/${realmName}/users/${usrid}/role-mappings/realm`,
+        auth: {
+          bearer: privates.get(client).accessToken
+        },
+        body: roles,
+        method: 'POST',
+        json: true
+      };
+
+      request(req, (err, resp, body) => {
+        if (err) {
+          return reject(err);
+        }
+
+        if (resp.statusCode !== 204) {
+          return reject(body);
+        }
+
+        return resolve(body);
+      });
+    });
+  };
+}
+
+/**
+  A function to unmap one or more realm roles to a given user
+  @param {string} realmName - The name of the realm (not the realmID) where the roles exist - ex: master
+  @param {string} usrid - The id of the user (UUID)
+  @param {string} roles - Array containing realm roles to be unassigned
+  @returns {Promise} A promise that will resolve with the Array of roles
+  @example
+  keycloakAdminClient(settings)
+    .then((client) => {
+      client.realms.maps.unmap(realmName, usrid, roles)
+        .then((unassignedRealmRoles) => {
+          console.log(unassignedRealmRoles)
+      })
+    })
+ */
+function unmap (client) {
+  return function unmap (realmName, usrid, roles) {
+    return new Promise((resolve, reject) => {
+      if (!usrid) {
+        return reject(new Error('user id is missing'));
+      }
+
+      if (!roles || !(roles instanceof Array) || roles.length === 0) {
+        return reject(new Error('roles are missing'));
+      }
+
+      const req = {
+        url: `${client.baseUrl}/admin/realms/${realmName}/users/${usrid}/role-mappings/realm`,
+        auth: {
+          bearer: privates.get(client).accessToken
+        },
+        body: roles,
+        method: 'DELETE',
+        json: true
+      };
+
+      request(req, (err, resp, body) => {
+        if (err) {
+          return reject(err);
+        }
+
+        if (resp.statusCode !== 204) {
+          return reject(body);
+        }
+
+        return resolve(body);
+      });
+    });
+  };
+}

--- a/lib/realm-roles.js
+++ b/lib/realm-roles.js
@@ -13,7 +13,7 @@ module.exports = {
 };
 
 /**
-  A function to get the all the roles of a client or a specific role for a client
+  A function to get the all the roles of a realm or a specific role for a realm
   @param {string} realmName - The name of the realm (not the realmID) where the client roles exist - ex: master
   @param {string} id - The id of the client (not the client-id) whose roles should be found
   @param {string} roleName - Optional name of a specific client role to find
@@ -21,14 +21,14 @@ module.exports = {
   @example
   keycloakAdminClient(settings)
     .then((client) => {
-      client.clients.roles.find(realmName, id)
+      client.realms.roles.find(realmName)
         .then((clientRoles) => {
           console.log(clientRoles)
       })
     })
  */
 function find (client) {
-  return function find (realmName, id, roleName) {
+  return function find (realmName, roleName) {
     return new Promise((resolve, reject) => {
       const req = {
         auth: {
@@ -38,9 +38,9 @@ function find (client) {
       };
 
       if (roleName) {
-        req.url = `${client.baseUrl}/admin/realms/${realmName}/clients/${id}/roles/${roleName}`;
+        req.url = `${client.baseUrl}/admin/realms/${realmName}/roles/${roleName}`;
       } else {
-        req.url = `${client.baseUrl}/admin/realms/${realmName}/clients/${id}/roles`;
+        req.url = `${client.baseUrl}/admin/realms/${realmName}/roles`;
       }
 
       request(req, (err, resp, body) => {
@@ -59,29 +59,28 @@ function find (client) {
 }
 
 /**
-  A function to create a new role.
+  A function to create a new realm role.
   @param {string} realmName - The name of the realm (not the realmID) where the client roles exist - ex: master
-  @param {string} id - The id of the client (not the client-id) whose roles should be found
   @param {object} newRole - The JSON representation of a role - http://www.keycloak.org/docs-api/3.0/rest-api/index.html#_rolerepresentation - name must be unique within the client
-  @returns {Promise} A promise that will resolve with the newly created client role
+  @returns {Promise} A promise that will resolve with the newly created realm role
   @example
   keycloakAdminClient(settings)
     .then((client) => {
-      client.clients.roles.create(realmName, id, newRole)
+      client.realms.roles.create(realmName, newRole)
         .then((createRole) => {
         console.log(createRole) // [{...}]
       })
     })
  */
 function create (client) {
-  return function create (realm, id, newRole) {
+  return function create (realm, newRole) {
     return new Promise((resolve, reject) => {
       if (!newRole) {
         return reject(new Error('role is missing'));
       }
 
       const req = {
-        url: `${client.baseUrl}/admin/realms/${realm}/clients/${id}/roles`,
+        url: `${client.baseUrl}/admin/realms/${realm}/roles`,
         auth: {
           bearer: privates.get(client).accessToken
         },
@@ -100,7 +99,7 @@ function create (client) {
         }
 
         // Since the create Endpoint returns an empty body, go get what we just imported.
-        return resolve(client.clients.roles.find(realm, id, newRole.name));
+        return resolve(client.realms.roles.find(realm, newRole.name));
       });
     });
   };

--- a/lib/realms.js
+++ b/lib/realms.js
@@ -2,6 +2,8 @@
 
 const privates = require('./private-map');
 const request = require('request');
+const roles = require('./realm-roles');
+const maps = require('./realm-role-mapper');
 
 /**
  * @module realms
@@ -11,7 +13,9 @@ module.exports = {
   find: find,
   create: create,
   remove: remove,
-  update: update
+  update: update,
+  roles: roles,
+  maps: maps
 };
 
 /**

--- a/lib/users.js
+++ b/lib/users.js
@@ -107,11 +107,14 @@ function create (client) {
           return reject(body);
         }
 
+        // eg "location":"https://<url>/auth/admin/realms/<realm>/users/499b7073-fe1f-4b7a-a8ab-f401d9b6b8ec"
+        const uid = resp.headers.location.replace(/.*\/(.*)$/, '$1');
+
         // Since the create Endpoint returns an empty body, go get what we just imported.
-        // But since we don't know the userId, we need to search based on the username, since it will be unique
-        // Then get the first element in the Array returned
+        // *** Body is empty but location header contains user id ***
+        // We need to search based on the userid, since it will be unique
         return resolve(client.users.find(realm, {
-          username: user.username
+          userId: uid
         })
           .then((user) => {
             return user[0];

--- a/test/realms-test.js
+++ b/test/realms-test.js
@@ -153,3 +153,118 @@ test('Test update a realm', (t) => {
     });
   });
 });
+
+test("Test getting realm's roles", (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    // Use the master realm
+    const realmName = 'master';
+
+    return client.realms.roles.find(realmName).then((roles) => {
+      t.equal(roles.length, 4, 'Should return 4 roles');
+
+      const expectedRole = {
+        id: 'e2892f14-c143-4b65-a3d3-7014c6270d7b',
+        name: 'offline_access',
+        description: `\${role_offline-access}`,
+        scopeParamRequired: true,
+        composite: false,
+        clientRole: false,
+        containerId: 'master'
+      };
+      t.deepEqual(roles.find((r) => r.id === expectedRole.id), expectedRole, 'Should have the offline_access role');
+    });
+  });
+});
+
+test("Test getting a realm's role", (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    // Use the master realm
+    const realmName = 'master';
+    const roleName = 'offline_access';
+
+    return client.realms.roles.find(realmName, roleName).then((role) => {
+      const expectedRole = {
+        id: 'e2892f14-c143-4b65-a3d3-7014c6270d7b',
+        name: 'offline_access',
+        description: `\${role_offline-access}`,
+        scopeParamRequired: true,
+        composite: false,
+        clientRole: false,
+        containerId: 'master'
+      };
+      t.deepEqual(role, expectedRole, 'Should return the offline_access role');
+    });
+  });
+});
+
+test("Test getting a realms's role - realm doesn't exist", (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  const realmName = 'not-a-valid-realm';
+  const roleName = 'not-a-real-role-name';
+  return kca.then((client) => {
+    return t.shouldFail(client.realms.roles.find(realmName, roleName), 'Could not find realm', 'Should return an error that no realm is found');
+  });
+});
+
+test("Test getting a realms's role - role name doesn't exist", (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  const realmName = 'master';
+  const roleName = 'not-a-real-role-name';
+  return kca.then((client) => {
+    return t.shouldFail(client.realms.roles.find(realmName, roleName), 'Could not find role', 'Should return an error that no role is found');
+  });
+});
+
+test("Test create a realm's role", (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    const realmName = 'master';
+    const newRole = {
+      name: 'my-new-role',
+      description: 'A new role'
+    };
+
+    return client.realms.roles.create(realmName, newRole).then((addedRole) => {
+      t.equal(addedRole.name, newRole.name, `The name should be named ${newRole.name}`);
+      t.equal(addedRole.description, newRole.description, `The description should be named ${newRole.description}`);
+    });
+  });
+});
+
+test("Test create a realm's role - realm doesn't exist", (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    const realmName = 'not-a-valid-realm';
+    const newRole = {
+      name: 'my-new-role',
+      description: 'A new role'
+    };
+
+    return kca.then((client) => {
+      return t.shouldFail(client.realms.roles.create(realmName, newRole), 'Could not find realm', 'Should return an error that no realm is found');
+    });
+  });
+});
+
+test("Test create a realm's role - a non-unique role name", (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    const realmName = 'master';
+    const newRole = {
+      name: 'offline_access'
+    };
+
+    return kca.then((client) => {
+      return t.shouldFail(client.realms.roles.create(realmName, newRole), `Role ${newRole.name} already exists`, 'Error message should be returned when using a non-unique role name');
+    });
+  });
+});

--- a/test/users-test.js
+++ b/test/users-test.js
@@ -219,6 +219,68 @@ test('Test listing groups of user', (t) => {
   });
 });
 
+test("Test realm's role user assignment", (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    t.equal(typeof client.realms.maps.map, 'function', 'The client object returned should have a realm role map function');
+
+    // Use the master realm
+    const realmName = 'master';
+    const userId = '3ff724a6-90a8-4050-9981-4a6def74870a';
+    const realmRoles = [{id: 'e2892f14-c143-4b65-a3d3-7014c6270d7b', name: 'offline_access'}];
+
+    return client.realms.maps.map(realmName, userId, realmRoles);
+  });
+});
+
+test("Test realm's role user unassignment", (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    t.equal(typeof client.realms.maps.map, 'function', 'The client object returned should have a realm role unmap function');
+
+    // Use the master realm
+    const realmName = 'master';
+    const userId = '3ff724a6-90a8-4050-9981-4a6def74870a';
+    const realmRoles = [{id: 'e2892f14-c143-4b65-a3d3-7014c6270d7b', name: 'offline_access'}];
+
+    return client.realms.maps.unmap(realmName, userId, realmRoles);
+  });
+});
+
+test("Test client's role user assignment", (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    t.equal(typeof client.clients.maps.map, 'function', 'The client object returned should have a client role map function');
+
+    // Use the master realm
+    const realmName = 'master';
+    const userId = '3ff724a6-90a8-4050-9981-4a6def74870a';
+    const clientId = '75ae84df-8541-4116-85a3-ed4a1ea154d6'; // "clientId" : "Test Realm 1-realm"
+    const clientRoles = [{id: '7371e2e3-fb68-482a-914b-d2dbd9a0a7ac', name: 'view-users'}];
+
+    return client.clients.maps.map(realmName, userId, clientId, clientRoles);
+  });
+});
+
+test("Test client's role user unassignment", (t) => {
+  const kca = keycloakAdminClient(settings);
+
+  return kca.then((client) => {
+    t.equal(typeof client.clients.maps.unmap, 'function', 'The client object returned should have a client role unmap function');
+
+    // Use the master realm
+    const realmName = 'master';
+    const userId = '3ff724a6-90a8-4050-9981-4a6def74870a';
+    const clientId = '75ae84df-8541-4116-85a3-ed4a1ea154d6'; // "clientId" : "Test Realm 1-realm"
+    const clientRoles = [{id: '7371e2e3-fb68-482a-914b-d2dbd9a0a7ac', name: 'view-users'}];
+
+    return client.clients.maps.unmap(realmName, userId, clientId, clientRoles);
+  });
+});
+
 test('Test reset password of user', (t) => {
   const kca = keycloakAdminClient(settings);
 


### PR DESCRIPTION
Hi,

New map/unmap funcs under clients and realms
for assigning a user to a given role.

Keep userid returned in location header after user creation.
Use it instead of username for complete user retrieval.

Thanks