### PR TITLE
Add execute action email

### DIFF
--- a/lib/users.js
+++ b/lib/users.js
@@ -16,7 +16,8 @@ module.exports = {
   remove: remove,
   roleMappings: roleMappings,
   groups: groups,
-  resetPassword: resetPassword
+  resetPassword: resetPassword,
+  executeActionsEmail: executeActionsEmail
 };
 
 /**
@@ -255,6 +256,89 @@ function resetPassword (c) {
 
         // Check that the status cod
         if (resp.statusCode !== 204) {
+          return reject(body);
+        }
+
+        return resolve(body);
+      });
+    });
+  };
+}
+
+/**
+  A function to execute predetermined keycloak email actions. For more information about what actions can be required by Keycloak please go here - https://keycloak.gitbooks.io/documentation/server_admin/topics/users/required-actions.html
+  @param {string} realmName - The name of the realm(not the realmID) - ex: master,
+  @param {string} userId - The id of user
+  @param {object} [options] - The options object
+  @param {string} [options.clientId] - The client ID that must be set in case of a redirect after actions
+  @param {string} [options.redirectUri] - The redirect URI after the user has completed the required actions on the Keycloak server. If this variable is set, it must be a valid redirect URI for the specified clientId variable, and the clientId variable MUST be set
+  @param {string} [options.verifyEmailAction] - Ask the user to verify his email address
+  @param {string} [options.updateProfileAction] - Ask the user to update his/her profile
+  @param {string} [options.updatePasswordAction] - Ask the user to change his/her password
+  @param {string} [options.configureTOTPAction] - Ask the user to configure TOTP (Time-based One-time Password Algorithm)
+  @returns {Promise} A promise that resolves.
+  @example
+  keycloakAdminClient(settings)
+    .then((client) => {
+      client.users.executeActionsEmail(realmName, userId, { verifyEmail: true, updateProfile: true, updatePassword: true, configureTOTP: true })
+        .then(() => {
+          console.log('success')
+      })
+    })
+ */
+function executeActionsEmail (c) {
+  return function executeActionsEmail (realmName, userId, options) {
+    return new Promise((resolve, reject) => {
+      options = options || {};
+
+      if (!userId) {
+        return reject(new Error('userId is missing'));
+      }
+
+      const payload = [];
+      if (options.verifyEmailAction) {
+        payload.push('VERIFY_EMAIL');
+      }
+      if (options.updateProfileAction) {
+        payload.push('UPDATE_PROFILE');
+      }
+      if (options.updatePasswordAction) {
+        payload.push('UPDATE_PASSWORD');
+      }
+      if (options.configureTOTPAction) {
+        payload.push('CONFIGURE_TOTP');
+      }
+
+      if (payload.length === 0) {
+        return reject(new Error('no actions defined'));
+      }
+
+      let queryParameter = '';
+      if (options.redirectUri !== '') {
+        if (options.clientId !== '') {
+          queryParameter = `?redirect_uri=${options.redirectUri}&client_id=${options.clientId}`;
+        } else {
+          return reject(new Error('clientId is not set but redirectUri is. Both MUST go together'));
+        }
+      }
+
+      const req = {
+        url: `${c.baseUrl}/admin/realms/${realmName}/users/${userId}/execute-actions-email${queryParameter}`,
+        auth: {
+          bearer: privates.get(c).accessToken
+        },
+        json: true,
+        method: 'PUT',
+        body: payload
+      };
+
+      request(req, (err, resp, body) => {
+        if (err) {
+          return reject(err);
+        }
+
+        // Check that the status cod
+        if (resp.statusCode !== 200) {
           return reject(body);
         }
 


### PR DESCRIPTION
Just added an utility method for keycloak predetermined required actions. Keycloak will send an email to the specified user, requiring him to take the wanted actions. 

The test doesn't pass because the user it's being run on doesn't have an email address. And even if it did have one, the Keycloak test server isn't configured to send emails, and would send a `500`
But I've tested it on our testing keycloak instance and it works.
